### PR TITLE
Fix IndexOutOfBoundsException when clear searched text in SearchView.

### DIFF
--- a/app/src/main/java/com/github/wrdlbrnft/searchablerecyclerviewdemo/ui/adapter/ExampleAdapter.java
+++ b/app/src/main/java/com/github/wrdlbrnft/searchablerecyclerviewdemo/ui/adapter/ExampleAdapter.java
@@ -86,13 +86,23 @@ public class ExampleAdapter extends RecyclerView.Adapter<ExampleViewHolder> {
     }
 
     public void addItem(int position, ExampleModel model) {
-        mModels.add(position, model);
-        notifyItemInserted(position);
+        if (position >= mModels.size()) {
+            mModels.add(model);
+            notifyItemInserted(mModels.size() - 1);
+        } else {
+            mModels.add(position, model);
+            notifyItemInserted(position);
+        }
     }
 
     public void moveItem(int fromPosition, int toPosition) {
         final ExampleModel model = mModels.remove(fromPosition);
-        mModels.add(toPosition, model);
-        notifyItemMoved(fromPosition, toPosition);
+        if (toPosition >= mModels.size()) {
+            mModels.add(model);
+            notifyItemMoved(fromPosition, mModels.size() - 1);
+        } else {
+            mModels.add(toPosition, model);
+            notifyItemMoved(fromPosition, toPosition);
+        }
     }
 }


### PR DESCRIPTION
When clear the searched text in the SearchView, it will lead to the problem IndexOutOfBoundsException due to filtered model has bigger size than mModel. So these code below could be problematic 

```
mModels.add(position, model);
mModels.add(toPosition, model);
```

Added logic to avoid this kind of issue
